### PR TITLE
add flush API

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -367,6 +367,9 @@ test(`body not parsed with flush`, async t => {
 
       const res = await gretch(`http://127.0.0.1:${port}`).flush();
 
+      t.truthy(res.url);
+      t.truthy(res.status);
+      t.truthy(res.response);
       // @ts-ignore
       t.falsy(res.error);
       // @ts-ignore

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -236,7 +236,7 @@ test(`body exists, will fail to parse non-json`, async t => {
 test(`won't parse body if Content-Length header doesn't exist`, async t => {
   const server = createServer((req, res) => {
     res.writeHead(200, {
-      "Content-Type": "application/json",
+      "Content-Type": "application/json"
     });
     res.end(JSON.stringify({ foo: true }));
   });
@@ -305,7 +305,7 @@ test(`hooks`, async t => {
           },
           after({ status }) {
             t.is(status, 200);
-          },
+          }
         }
       }).json();
 
@@ -331,17 +331,48 @@ test(`create`, async t => {
 
       const wrappedGretch = create({
         headers: {
-          'Foo': 'Bar',
-        },
+          Foo: "Bar"
+        }
       });
 
       await wrappedGretch(`http://127.0.0.1:${port}`, {
         hooks: {
           before(request, opts) {
-            t.is(opts.headers.Foo, 'Bar');
-          },
+            t.is(opts.headers.Foo, "Bar");
+          }
         }
       }).json();
+
+      server.close();
+
+      r();
+    });
+  });
+});
+
+test(`body not parsed with flush`, async t => {
+  const server = createServer((req, res) => {
+    const body = { message: "foo" };
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": JSON.stringify(body).length
+    });
+    res.end(JSON.stringify(body));
+  });
+
+  await new Promise(r => {
+    server.listen(async () => {
+      // @ts-ignore
+      const { port } = server.address();
+
+      const res = await gretch(`http://127.0.0.1:${port}`).flush();
+
+      // @ts-ignore
+      t.falsy(res.error);
+      // @ts-ignore
+      t.falsy(res.data);
+
+      t.pass();
 
       server.close();
 


### PR DESCRIPTION
Previously, the only way to resolve the initial request was to _also_ parse the body. This affects performance, especially if all we want to do is check the `status` of the request.

This PR adds a `flush()` method that simply resolves the request and returns a subset of the `GretchResponse` object.

```js
async function isLoggedIn() {
  const { url, status, response } = await gretch('/api/user/me').flush();
  return status < 399;
}
```

In the process I opted for more explicit type defs. I also added a test.