### PR TITLE
adds baseURL option, tests, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,44 @@ const gretch = create({
 await gretch("/api/user/12").json();
 ```
 
+### Base URLs
+
+Another common use case for creating a separate instance is to specify a
+`baseURL` for all requests. The `baseURL` will then be resolved against the base
+URL of the page, allowing support for both absolute and relative `baseURL`
+values.
+
+In the example below, assume requests are being made from a page located at
+`https://www.mysite.com`.
+
+Functionally, this:
+
+```js
+const gretch = create({
+  baseURL: "https://www.mysite.com/api"
+});
+```
+
+Is equivalent to this:
+
+```js
+const gretch = create({
+  baseURL: "/api"
+});
+```
+
+So this request:
+
+```js
+await gretch("/user/12").json();
+```
+
+Will resolve to `https://www.mysite.com/api/user/12`.
+
+**Note:** if a `baseURL` is specified, URLs will be normalized in order to
+concatenate them i.e. a leading slash – `/user/12` vs `user/12` – will not
+impact how the request is resolved.
+
 ## Usage with TypeScript
 
 `gretchen` is written in TypeScript and employs a _discriminated union_ to allow

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ import {
   RetryOptions
 } from "./lib/handleRetry";
 import { handleTimeout } from "./lib/handleTimeout";
+import { normalizeURL } from "./lib/utils";
 
 export type DefaultGretchResponse = any;
 export type DefaultGretchError = any;
@@ -32,6 +33,7 @@ export type GretchHooks = {
 };
 
 export type GretchOptions = {
+  baseURL?: string;
   json?: { [key: string]: any };
   retry?: RetryOptions | boolean;
   timeout?: number;
@@ -56,6 +58,7 @@ export function gretch<T = DefaultGretchResponse, A = DefaultGretchError>(
 ): GretchInstance<T, A> {
   const {
     method = "GET",
+    baseURL,
     json,
     retry = defaultRetryOptions,
     timeout = 10000,
@@ -83,7 +86,9 @@ export function gretch<T = DefaultGretchResponse, A = DefaultGretchError>(
     options.body = JSON.stringify(json);
   }
 
-  const request = new Request(url, options);
+  const normalizedURL =
+    baseURL !== undefined ? normalizeURL(url, { baseURL }) : url;
+  const request = new Request(normalizedURL, options);
 
   if (hooks.before) hooks.before(request, opts);
 
@@ -101,7 +106,7 @@ export function gretch<T = DefaultGretchResponse, A = DefaultGretchError>(
     async flush() {
       const response = (await sent).clone();
       return {
-        url,
+        url: normalizedURL,
         status: response.status,
         response
       };
@@ -137,7 +142,7 @@ export function gretch<T = DefaultGretchResponse, A = DefaultGretchError>(
       }
 
       const res: GretchResponse<T, A> = {
-        url,
+        url: normalizedURL,
         status,
         data,
         error,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,9 @@
+export function normalizeURL(
+  url: string,
+  { baseURL = "" }: { baseURL: string }
+) {
+  return (
+    (/\/$/.test(baseURL) ? baseURL : baseURL + "/") +
+    (/^\//.test(url) ? url.replace(/^\//, "") : url)
+  );
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,4 @@
-export function normalizeURL(
-  url: string,
-  { baseURL = "" }: { baseURL: string }
-) {
+export function normalizeURL(url: string, { baseURL }: { baseURL: string }) {
   return (
     (/\/$/.test(baseURL) ? baseURL : baseURL + "/") +
     (/^\//.test(url) ? url.replace(/^\//, "") : url)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -350,6 +350,28 @@ test(`create`, async t => {
   });
 });
 
+test(`create with baseURL`, async t => {
+  const wrappedGretch = create({
+    baseURL: `http://www.foo.com`
+  });
+
+  const res = await wrappedGretch("api").json();
+
+  t.is(res.url, `http://www.foo.com/api`);
+});
+
+test(`create with baseURL, override per request`, async t => {
+  const wrappedGretch = create({
+    baseURL: `http://www.foo.com`
+  });
+
+  const res = await wrappedGretch("/api", {
+    baseURL: `http://www.bar.com`
+  }).json();
+
+  t.is(res.url, `http://www.bar.com/api`);
+});
+
 test(`body not parsed with flush`, async t => {
   const server = createServer((req, res) => {
     const body = { message: "foo" };

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,26 @@
+import test from "ava";
+
+import { normalizeURL } from "../lib/utils";
+
+test("normalizeURL", t => {
+  const url = "https://www.foo.com/api/v1/user";
+  const baseURL = "https://www.foo.com";
+
+  const one = normalizeURL("api/v1/user", { baseURL });
+  t.truthy(one === url);
+
+  // trailing slash
+  const two = normalizeURL("api/v1/user", { baseURL: baseURL + "/" });
+  t.truthy(two === url);
+
+  // leading slashe
+  const three = normalizeURL("/api/v1/user", { baseURL });
+  t.truthy(three === url);
+
+  // no slashes
+  const four = normalizeURL("api/v1/user", { baseURL });
+  t.truthy(four === url);
+
+  const five = normalizeURL("", { baseURL: "http://localhost:8080" });
+  t.truthy(five === "http://localhost:8080/");
+});


### PR DESCRIPTION
Allows users to provide a base URL from which to make requests. Allows for:
- avoiding repeating paths like `/api/v1` for all fetchers
- specifying a different URL origin from the page you're on
- could be used to ensure absolute URLs are used for all requests (our current use case)

See tests, but this value can also be overridden on a per-request level.