### PR TITLE
Add CI to legacy branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,29 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - legacy
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Installing dependencies
+        run: npm i
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm run test
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.TRUEWORK_TEAM_NPM_TOKEN }}
+        run: npm publish || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    name: Pre-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Installing dependencies
+        run: npm i
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - "**"
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .rts2_cache_cjs/
 .rts2_cache_es/
 .rts2_cache_umd/
+node_modules


### PR DESCRIPTION
Problem: We're running Gretchen 1.1.0 and want to make a one-line change, but CI/CD is only configured for other versions.

Solution: Add a `legacy` branch, enable branch protections, and backport CI from `master` to this branch. This does not support publishing, that will need to happen manually.