### PR TITLE
Use latest npm for publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.TRUEWORK_TEAM_NPM_TOKEN }}
-        run: npm whoami && npm publish || true
+        run: npx npm@latest whoami && npx npm@latest publish || true


### PR DESCRIPTION
Problem: Apparently setup-node doesn't work with our very old npm version.

Solution: Use a newer npm version when doing a whoami and publish.