### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.TRUEWORK_TEAM_NPM_TOKEN }}
-        run: npm whoami && npm publish || true
+        run: npm publish || true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "microbundle build",
     "watch": "microbundle watch",
-    "publish": "npm publish",
     "postbuild": "npm run test",
     "test": "ava tests/**.test.ts --verbose"
   },


### PR DESCRIPTION
Problem: We have a script that's trying to double-publish to npm.

Solution: Remove it and remove the `npm whoami`.