### PR TITLE
fix: bump latest npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gretchen",
       "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
@@ -11058,6 +11059,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
The `legacy` branch uses `npm publish` which by default uses the `latest` tag on npm, which means new installs like `npm i gretchen` are pulling down `1.1.0-1` 😛 

This empty commit should bop Semantic Release into publishing a new version `1.5.1` as `latest`.

Also, miss you guys ❤️ 